### PR TITLE
FIX errors with file option (close #72) and pipe

### DIFF
--- a/deepl/deepl.py
+++ b/deepl/deepl.py
@@ -93,7 +93,7 @@ class DeepLCLI:
         if not self.internet_on():
             raise DeepLCLIPageLoadError("Your network seem to be offline.")
         self._chk_script(script)
-        script = quote(script.replace("/", r"\/"), safe="")
+        script = quote(script.replace("/", r"\/").replace("|", r"\|"), safe="")
         return asyncio.get_event_loop().run_until_complete(self._translate(script))
 
     async def _translate(self, script: str) -> str:

--- a/deepl/main.py
+++ b/deepl/main.py
@@ -21,7 +21,9 @@ class DeepLCLIFormatter(
 
 def check_file(v: str) -> str:
     def is_binary_string(b: bytes) -> bool:
-        textchars = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F})
+        textchars = bytearray(
+            {7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F}
+        )
         return bool(b.translate(None, textchars))
 
     if not os.path.isfile(v):

--- a/deepl/main.py
+++ b/deepl/main.py
@@ -5,7 +5,6 @@ import os
 import sys
 import warnings
 from shutil import get_terminal_size
-from typing import cast
 
 from deepl import __version__
 
@@ -22,12 +21,12 @@ class DeepLCLIFormatter(
 
 def check_file(v: str) -> str:
     def is_binary_string(b: bytes) -> bool:
+        textchars = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F})
         return bool(b.translate(None, textchars))
 
-    textchars = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F})
     if not os.path.isfile(v):
         raise argparse.ArgumentTypeError(f"{repr(v)} is not file.")
-    elif not is_binary_string(cast(bytes, open(v, "rb"))):
+    elif is_binary_string(open(v, "rb").read(1024)):
         raise argparse.ArgumentTypeError(f"{repr(v)} is not text file.")
     else:
         return v


### PR DESCRIPTION
- The `-f` option now works fine.
- We need to escape pipe character because Deepl use this as delimiter between original and translated text.