### PR TITLE
Emulate chrome window size

### DIFF
--- a/deepl/deepl.py
+++ b/deepl/deepl.py
@@ -106,7 +106,7 @@ class DeepLCLI:
                 "--disable-dev-shm-usage",
                 "--disable-gpu",
                 "--no-zygote",
-                "--window-size=1920,1080"
+                "--window-size=1920,1080",
             ],
         )
         page: Page = await browser.newPage()

--- a/deepl/deepl.py
+++ b/deepl/deepl.py
@@ -106,6 +106,7 @@ class DeepLCLI:
                 "--disable-dev-shm-usage",
                 "--disable-gpu",
                 "--no-zygote",
+                "--window-size=1920,1080"
             ],
         )
         page: Page = await browser.newPage()
@@ -120,7 +121,7 @@ class DeepLCLI:
         try:
             page.waitForSelector("#dl_translator > div.lmt__text", timeout=15000)
         except TimeoutError:
-            raise DeepLCLIPageLoadError("Time limit exceeded. (30000ms)")
+            raise DeepLCLIPageLoadError("Time limit exceeded. (15000ms)")
 
         try:
             await page.waitForFunction(


### PR DESCRIPTION
It seems that deepl has now started to check the size of the window and does not give a result if it is null, this patch fixes that.