### PR TITLE
rename d-textarea[data-testid=translator-target-input]

### DIFF
--- a/deepl/deepl.py
+++ b/deepl/deepl.py
@@ -109,7 +109,7 @@ class DeepLCLI:
                 await page.wait_for_function(
                     """
                     () => document.querySelector(
-                    'd-textarea[dl-test=translator-target-input]')?.value?.length > 0
+                    'd-textarea[data-testid=translator-target-input]')?.value?.length > 0
                 """,
                 )
             except PlaywrightError as e:


### PR DESCRIPTION
www.deepl.com d-textarea[dl-test=translator-target-input] renamed to d-textarea[data-testid=translator-target-input]