### PR TITLE
fix playwright._impl._errors.TargetClosedError: Target page, context or browser has been closed on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        # - windows-latest
+        - windows-latest
         - macos-latest
         python-version:
         # - '3.8'

--- a/deepl/deepl.py
+++ b/deepl/deepl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import asyncio
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -187,7 +188,7 @@ class DeepLCLI:
             headless=True,
             args=[
                 "--no-sandbox",
-                "--single-process",
+                "--single-process" if os.name != "nt" else "",
                 "--disable-dev-shm-usage",
                 "--disable-gpu",
                 "--no-zygote",


### PR DESCRIPTION
Fix https://github.com/eggplants/deepl-cli/issues/221

> according to [chromium-dev](https://groups.google.com/a/chromium.org/g/chromium-dev/c/l-D-cI0L7DA/m/2kQk8gJd8gsJ): 
The code for chrome is split between two DLLs, but there's some code duplicated (base, etc.). Only one DLL is loaded into each chrome process (chrome.dll for the browser, chrome_child.dll for others). We didn't attempt to keep single process working in that mode as it was unnecessary and potentially tricky/confusing given two copies of the same code in the same processes.
Setting chrome_multiple_dll=0 at gyp time is probably the simplest solution for single process mode in Chrome.


The main issue is that Chromium on Windows is built with `chrome_multiple_dll=0`, which does not support the `--single-process` flag. This leads to failures when attempting to run Chromium in a single process mode on Windows, the browser crashes immediately after launch.

## Fix:
If the platform is Windows, the `--single-process` flag will be automatically disabled to ensure compatibility. On non-Windows platforms, the flag will still be used as expected.

## Testing Results:
Tested on [my fork](https://github.com/sakkyoi/deepl-cli/actions/runs/10835003288), and the following outcomes were observed:
- On Windows: `--single-process` is disabled, and Chromium runs without issues.
- On Linux/macOS: `--single-process` works as expected, with no regressions or failures.

All relevant test have passed successfully in both environments.