### PR TITLE
Replaced startsWith with includes

### DIFF
--- a/deepl/deepl.py
+++ b/deepl/deepl.py
@@ -221,7 +221,7 @@ class DeepLCLI:
                             t = document.querySelector(
                                 'd-textarea[aria-labelledby=translation-target-heading]',
                             )?.children[0]?.children[{line_index}]?.innerText ?? '';
-                            return t.length > 0 && !t.startsWith('[...]');
+                            return t.length > 0 && !t.includes('[...]');
                         }}
                         """,
                     )


### PR DESCRIPTION
Unfortunately startsWith is not reliable because `[...]` can be added even in the middle of a line (e.g. at the beginning of any sentence).

I wish the tag had a relevant property, but unfortunately it doesn't.